### PR TITLE
add an option to only display pages in the current language

### DIFF
--- a/cmsplugin_htmlsitemap/cms_plugins.py
+++ b/cmsplugin_htmlsitemap/cms_plugins.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.contrib.sites.models import Site
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, get_language
 
 from cms.models.pagemodel import Page
 from cms.plugin_base import CMSPluginBase
@@ -22,6 +22,8 @@ class HtmlSitemapPlugin(CMSPluginBase):
         pages = pages.filter(level__gte=instance.level_min, level__lte=instance.level_max)
         if not instance.in_navigation is None:
             pages = pages.filter(in_navigation=instance.in_navigation)
+        if instance.match_language:
+            pages = pages.filter(title_set__language=get_language())
         if instance.match_created_by:
             pages = pages.filter(created_by=instance.match_created_by)
         if instance.match_title:

--- a/cmsplugin_htmlsitemap/migrations/0002_auto__add_field_htmlsitemap_match_language.py
+++ b/cmsplugin_htmlsitemap/migrations/0002_auto__add_field_htmlsitemap_match_language.py
@@ -1,0 +1,55 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'HtmlSitemap.match_language'
+        db.add_column('cmsplugin_htmlsitemap', 'match_language', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'HtmlSitemap.match_language'
+        db.delete_column('cmsplugin_htmlsitemap', 'match_language')
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        'cmsplugin_htmlsitemap.htmlsitemap': {
+            'Meta': {'ordering': "('level_min', 'level_max')", 'object_name': 'HtmlSitemap', 'db_table': "'cmsplugin_htmlsitemap'", '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'in_navigation': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'level_max': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '100'}),
+            'level_min': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'match_created_by': ('django.db.models.fields.CharField', [], {'max_length': '70', 'blank': 'True'}),
+            'match_language': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'match_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'match_url': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['cmsplugin_htmlsitemap']

--- a/cmsplugin_htmlsitemap/models.py
+++ b/cmsplugin_htmlsitemap/models.py
@@ -17,6 +17,7 @@ class HtmlSitemap(CMSPlugin):
         max_length=255)
     match_url = models.CharField(_('URL match with regular expression'), blank=True,
         max_length=100)
+    match_language = models.BooleanField(_('match only pages in current language'), default=False)
 
     class Meta:
         verbose_name = _('HTML Sitemap plugin')


### PR DESCRIPTION
I'm working on a web site with multiple languages and I use your HTML sitemap plugin - really neat. I needed a way to filter only pages in the current site language (to avoid overcrowding the page with too many links).

This is the change I did to the HTML sitemap plugin. I expect others also need this feature, so I decided to submit this pull request to you. Please let me know if further changes are needed. Thanks!
