### PR TITLE
Fix to remove draft cms pages from the sitemap

### DIFF
--- a/cmsplugin_htmlsitemap/cms_plugins.py
+++ b/cmsplugin_htmlsitemap/cms_plugins.py
@@ -20,6 +20,7 @@ class HtmlSitemapPlugin(CMSPluginBase):
         site = Site.objects.get_current()
         pages = Page.objects.published(site=site).order_by('tree_id', 'lft')
         pages = pages.filter(level__gte=instance.level_min, level__lte=instance.level_max)
+        pages = pages.filter(publisher_is_draft=0)
         if not instance.in_navigation is None:
             pages = pages.filter(in_navigation=instance.in_navigation)
         if instance.match_language:


### PR DESCRIPTION
Fix to remove draft cms pages from the sitemap, which causes duplication.
