### PR TITLE
Limit results to published pages

### DIFF
--- a/cmsplugin_htmlsitemap/cms_plugins.py
+++ b/cmsplugin_htmlsitemap/cms_plugins.py
@@ -18,10 +18,9 @@ class HtmlSitemapPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         site = Site.objects.get_current()
-        pages = Page.objects.published(site=site).order_by('tree_id', 'lft')
+        pages = Page.objects.public().published(site=site).order_by('tree_id', 'lft')
         pages = pages.filter(level__gte=instance.level_min,
-                             level__lte=instance.level_max,
-                             publisher_is_draft=False)
+                             level__lte=instance.level_max)
         if not instance.in_navigation is None:
             pages = pages.filter(in_navigation=instance.in_navigation)
         if instance.match_language:


### PR DESCRIPTION
Use the public() method of PageManager to filter published pages rather than direct attribute access.

When I upgraded to Django-CMS 3, my HTMLSitemap was mysteriously blank. This call to public() remedied the problem. The public method existed in previous version of Django-CMS. Judging by the use in the Django-CMS code, it appears to be the officially sanctioned method of retrieving published pages.
